### PR TITLE
Fix two code of conduct typos

### DIFF
--- a/_posts/2015-03-03-codeofconduct.md
+++ b/_posts/2015-03-03-codeofconduct.md
@@ -9,7 +9,7 @@ fa-icon: group
 
 “EMS” in this document refers to the Engineering Manager Slack chat group at [engmanagers.slack.com](http://eng-managers.slack.com). “The administrators” refers to the administrators on this organization, a list is available at the top of the [Team Directory](https://eng-managers.slack.com/team) (must be a member of the organization to view). 
 
-EMS operates under [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule). You are free to use the information in EMS in other contexts, however you should not disclose the the identity or affliation of any commenter in EMS.
+EMS operates under [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule). You are free to use the information in EMS in other contexts, however you should not disclose the identity or affiliation of any commenter in EMS.
 
 EMS is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form. 
 


### PR DESCRIPTION
While reading the code of conduct, I noticed two typos:

1. Duplication of "the"
1. Mis-spelling of "affiliation"

This fixes both.