### PR TITLE
Removed twitter as a sign-up mechanism.

### DIFF
--- a/_posts/2015-03-04-join.md
+++ b/_posts/2015-03-04-join.md
@@ -5,8 +5,4 @@ color: white   #text color
 fa-icon: key
 ---
 
-## You can request an invitation by sending a message on twitter to [@catehstn](https://twitter.com/catehstn) or [@stevebennett](https://twitter.com/stevebennett)
-
-Alternatively, complete our [Google Form](https://docs.google.com/forms/d/e/1FAIpQLSehqlNr40VFrhFbI3vo7k6MYpmQaVRcFzFG_FUYI0wOM6Exhw/viewform) to request an invite.
-
-
+## To request an invite, please complete our [Google Form](https://docs.google.com/forms/d/e/1FAIpQLSehqlNr40VFrhFbI3vo7k6MYpmQaVRcFzFG_FUYI0wOM6Exhw/viewform).


### PR DESCRIPTION
In line with recent announcements in the Slack team, we're removing the ability to request an invite to the team through DM channels such as Twitter. These changes remove Cate and Steve's Twitter handles, and makes the Google Form the only way to sign-up.